### PR TITLE
Responsive images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/widgets/class-gencwooc-featured-products.php
+++ b/widgets/class-gencwooc-featured-products.php
@@ -185,7 +185,7 @@ class Gencwooc_Featured_Products extends WC_Widget {
 	}
 
 	/**
-	 * Function to retrieve the actual product categories as an assosiative array. Used to output
+	 * Function to retrieve the actual product categories as an associative array. Used to output
 	 * a dropdown in the widget settings.
 	 *
 	 * @return array Associative array of product categories.
@@ -211,7 +211,7 @@ class Gencwooc_Featured_Products extends WC_Widget {
 	 * Function to retrieve an associative array containing all possible featured image sizes to
 	 * be used.
 	 *
-	 * @return array Associative array containg possible image sizes and dimensions.
+	 * @return array Associative array containing possible image sizes and dimensions.
 	 */
 	public function get_featured_image_sizes() {
 
@@ -231,7 +231,7 @@ class Gencwooc_Featured_Products extends WC_Widget {
 	 * Main function to retrieve a WP_Query object with appropriate arguments passed in from
 	 * the instance.
 	 *
-	 * @param array $args     Widgdet instance arguments.
+	 * @param array $args     Widget instance arguments.
 	 * @param array $instance Instance arguments to be used in the query.
 	 *
 	 * @return object New WP_Query object to be looped through.

--- a/widgets/class-gencwooc-featured-products.php
+++ b/widgets/class-gencwooc-featured-products.php
@@ -391,12 +391,12 @@ class Gencwooc_Featured_Products extends WC_Widget {
 						printf(
 							'<a href="%s" class="entry-image-wrap">%s</a>',
 							esc_url( get_permalink() ),
-							wp_make_content_images_responsive( $image ) // phpcs:ignore WordPress.Security.EscapeOutput
+							$image // phpcs:ignore WordPress.Security.EscapeOutput
 						);
 					} else {
 						printf(
 							'<div class="entry-image-wrap">%s</div>',
-							wp_make_content_images_responsive( $image ) // phpcs:ignore WordPress.Security.EscapeOutput
+							$image // phpcs:ignore WordPress.Security.EscapeOutput
 						);
 					}
 				}


### PR DESCRIPTION
Images already get `srcset` via `wp_calculate_image_srcset` in `wp_get_attachment_image`. 

`wp_make_content_images_responsive` is deprecated in WordPress 5.5.

Fixes #52

### How to test
<!-- Detailed steps to test this PR. -->
1. Install WP 5.5, WooCommerce and a Genesis child theme along with this plugin branch.
2. Add `add_theme_support( 'gencwooc-featured-products-widget' );` to the child theme.
3. Add a Genesis - Featured Products widget to a widget area.
4. Make sure the image includes `srcset` and `sizes`.

### Documentation
No documentation required. 
<!-- Documentation required. See #xxx. -->
<!-- PR includes documentation. -->

### Suggested changelog entry
<!-- A short description for the changelog. -->
Removed use of `wp_make_content_images_responsive` featured product widget images; `srcset` is applied via `wp_calculate_image_srcset` in `wp_get_attachment_image` used by `genesis_get_image`.

### Notes
<!-- Additional information for reviewers. -->

Import product xml is available here: https://my.studiopress.com/documentation/woocommerce/woocommerce-integration/how-to-import-the-demo-products/ (Okta or StudioPress account login)