### PR TITLE
Release/1.1.1

### DIFF
--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -13,7 +13,7 @@
  * Requires at least: 4.7
  *
  * WC requires at least: 3.3.0
- * WC tested up to: 4.3.3
+ * WC tested up to: 4.4.0
  *
  * @package Genesis_Connect_WooCommerce
  *

--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -11,7 +11,7 @@
  * License URI: http://www.opensource.org/licenses/gpl-license.php
  *
  * WC requires at least: 3.3.0
- * WC tested up to: 3.6.4
+ * WC tested up to: 4.3.3
  *
  * @package Genesis_Connect_WooCommerce
  *

--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Genesis Connect for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/genesis-connect-woocommerce/
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  * Description: Allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.

--- a/genesis-connect-woocommerce.php
+++ b/genesis-connect-woocommerce.php
@@ -9,6 +9,8 @@
  * Text Domain: gencwooc
  * License: GNU General Public License v2.0 (or later)
  * License URI: http://www.opensource.org/licenses/gpl-license.php
+ * Requires PHP: 5.6
+ * Requires at least: 4.7
  *
  * WC requires at least: 3.3.0
  * WC tested up to: 4.3.3

--- a/languages/genesis-connect-woocommerce.pot
+++ b/languages/genesis-connect-woocommerce.pot
@@ -1,17 +1,17 @@
-# Copyright (C) 2019 StudioPress
+# Copyright (C) 2020 StudioPress
 # This file is distributed under the same license as the Genesis Connect for WooCommerce plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Genesis Connect for WooCommerce 1.1.0\n"
+"Project-Id-Version: Genesis Connect for WooCommerce 1.1.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/genesis-connect-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-07-10T15:02:37+00:00\n"
+"POT-Creation-Date: 2020-08-20T15:06:02+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.1.0\n"
+"X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: gencwooc\n"
 
 #. Plugin Name of the plugin
@@ -42,14 +42,6 @@ msgstr ""
 msgid "Genesis Connect for WooCommerce requires WooCommerce. Please activate WooCommerce or disable Genesis Connect."
 msgstr ""
 
-#: lib/template-loader.php:178
-msgid "Search Results:"
-msgstr ""
-
-#: lib/template-loader.php:181
-msgid "Page"
-msgstr ""
-
 #: lib/breadcrumb.php:67
 msgid "Search results for &ldquo;"
 msgstr ""
@@ -74,6 +66,14 @@ msgstr ""
 
 #: lib/posts-per-page.php:70
 msgid "This setting determines how many products show up on archive pages and may be overridden by filters used in themes and plugins."
+msgstr ""
+
+#: lib/template-loader.php:178
+msgid "Search Results:"
+msgstr ""
+
+#: lib/template-loader.php:181
+msgid "Page"
 msgstr ""
 
 #: widgets/class-gencwooc-featured-products.php:54

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Plugin Name ===
-Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale
+Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale, wpengine, dreamwhisper
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 3.3
 Tested up to: 5.4

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbat
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 3.3
 Tested up to: 5.4
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 
 This plugin allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale, wpengine, dreamwhisper
 Tags: genesis, genesiswp, studiopress, woocommerce
 Requires at least: 3.3
-Tested up to: 5.4
+Tested up to: 5.5
 Stable tag: 1.1.1
 
 This plugin allows you to seamlessly integrate WooCommerce with the Genesis Framework and Genesis child themes.

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,9 @@ For the benefit of theme developers and customizers, here is a summary of possib
 
 == Changelog ==
 
+= 1.1.1 =
+* Removed use of `wp_make_content_images_responsive` featured product widget images; srcset is applied via `wp_calculate_image_srcset` in `wp_get_attachment_image` used by `genesis_get_image`.
+
 = 1.1.0 =
 * Added php codesniffer via composer package for WordPress code standards.
 * Fixed spacing and syntax issues for WordPress code standards.
@@ -155,8 +158,8 @@ For the benefit of theme developers and customizers, here is a summary of possib
 * Allow network activation on WordPress multisite networks.
 
 = 0.9.10 =
-* Update theme templates for WooCommerce 3.3
-* Add Featured Products Widget
+* Update theme templates for WooCommerce 3.3.
+* Add Featured Products Widget.
 
 = 0.9.9 =
 * Released 12 January 2017
@@ -167,7 +170,7 @@ For the benefit of theme developers and customizers, here is a summary of possib
 
 = 0.9.8 =
 * Released 9 July 2014
-* Updates genesiswooc_content_product() to reflect WooCommerce 2.1+ templates and correct handling of WooCommerce page title filter function
+* Updates genesiswooc_content_product() to reflect WooCommerce 2.1+ templates and correct handling of WooCommerce page title filter function.
 
 = 0.9.7 =
 * Released 22 December 2013
@@ -179,24 +182,24 @@ For the benefit of theme developers and customizers, here is a summary of possib
 
 = 0.9.5 =
 * Released 14 March 2013
-* add_theme_support( 'woocommerce' ) added to ensure compatibility with WooCommerce 2.0+
+* add_theme_support( 'woocommerce' ) added to ensure compatibility with WooCommerce 2.0+.
 
 = 0.9.4 =
 * Released 19 July 2012
-* Tweaked archive-product.php and taxonomy.php loop functions to provide compatibility with WooCommerce 1.6.0
+* Tweaked archive-product.php and taxonomy.php loop functions to provide compatibility with WooCommerce 1.6.0.
 
 = 0.9.3 =
 * Released 14 May 2012
-* taxonomy.php and archive-product.php now use woocommerce_get_template_part() instead of gencwooc_get_template_part()
+* taxonomy.php and archive-product.php now use woocommerce_get_template_part() instead of gencwooc_get_template_part().
 * gencwooc_get_template_part() updated to reflect latest version of woocommerce_get_template_part(). Note: gencwooc_get_template_part() will be deprecated in a future version and is only retained for backwards compatibility.
 
 = 0.9.2 =
 * Released 15 March 2012
-* single-product.php - Single product title template file now hooked in as per WooCommerce 1.5.2
+* single-product.php - Single product title template file now hooked in as per WooCommerce 1.5.2.
 
 = 0.9.1 =
 * Released 6 March 2012
-* Fixes call to undefined function error in sp-plugins-integration/genesis-simple-sidebars.php
+* Fixes call to undefined function error in sp-plugins-integration/genesis-simple-sidebars.php.
 
 = 0.9.0 =
-* Initial Release
+* Initial Release.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Plugin Name ===
 Contributors: nathanrice, studiopress, studiograsshopper, modernnerd, marksabbath, calvinkoepke, curtismchale, wpengine, dreamwhisper
 Tags: genesis, genesiswp, studiopress, woocommerce
-Requires at least: 3.3
+Requires at least: 4.7
 Tested up to: 5.5
 Stable tag: 1.1.1
 


### PR DESCRIPTION
1.1.1 Release PR

= 1.1.1 =
* Removed use of `wp_make_content_images_responsive` featured product widget images; srcset is applied via `wp_calculate_image_srcset` in `wp_get_attachment_image` used by `genesis_get_image`.


- Bumps tested up to
- Adds contributors
- Bumps WC tested up to (twice since it updated again)
- Adds minimum WP version
- Updates version
